### PR TITLE
fix(CI): Fixed staging branch name to 'Staging'

### DIFF
--- a/.github/workflows/mirroring.yml
+++ b/.github/workflows/mirroring.yml
@@ -2,8 +2,7 @@ name: Mirror to Main Repository
 
 on:
   push:
-    branches:
-      - staging
+    branches: [ "Staging" ]
 
 jobs:
   mirror:


### PR DESCRIPTION
## Contexte
Fixed Staging branche name in Mirroring CI

## Changements
- Staging branch name in mirroring CI

## Vérifications
- [x] Tests ajoutés ou mis à jour si nécessaire
- [x] Docs mises à jour si nécessaire
