### PR TITLE
fix(CI): Fixed staging branch name to 'Staging' and Fixed bad rsync

### DIFF
--- a/.github/workflows/mirroring.yml
+++ b/.github/workflows/mirroring.yml
@@ -24,14 +24,17 @@ jobs:
 
       - name: Sync content
         run: |
-          cd main-repo
-          git checkout staging || git checkout -b staging
-
-          mkdir -p $REPO_NAME
+          mkdir source-copy
           rsync -av --delete \
             --exclude '.git' \
             --exclude '.github' \
-            ../ $REPO_NAME/
+            ./ source-copy/
+
+          cd main-repo
+          git checkout Staging || git checkout -b Staging
+
+          mkdir -p $REPO_NAME
+          rsync -av --delete source-copy/ $REPO_NAME/
 
       - name: Commit and push if changes
         run: |
@@ -43,7 +46,7 @@ jobs:
 
           if ! git diff --cached --quiet; then
             git commit -m "Sync $REPO_NAME from staging"
-            git push origin staging
+            git push origin Staging
           else
             echo "No changes to commit"
           fi


### PR DESCRIPTION
## Contexte
Fixed staging branch name to 'Staging' and Fixed bad rsync

## Changements
- Fixed CI

## Vérifications
- [x] Tests ajoutés ou mis à jour si nécessaire
- [x] Docs mises à jour si nécessaire
