### PR TITLE
fix(CI): Fixed access token not set for push

### DIFF
--- a/.github/workflows/mirroring.yml
+++ b/.github/workflows/mirroring.yml
@@ -20,7 +20,12 @@ jobs:
 
       - name: Clone main repository
         run: |
-          git clone https://x-access-token:${{ secrets.MAIN_REPO_TOKEN }}@github.com/OverDrive-Motorsports/OverDrive.git main-repo
+          git clone https://github.com/OverDrive-Motorsports/OverDrive.git main-repo
+
+      - name: Configure authenticated remote
+        run: |
+          cd main-repo
+          git remote set-url origin https://x-access-token:${{ secrets.MAIN_REPO_TOKEN }}@github.com/OverDrive-Motorsports/OverDrive.git
 
       - name: Sync content
         run: |


### PR DESCRIPTION
## Contexte
Fixed access token not set for push in CI

## Changements
- Fixed CI

## Vérifications
- [x] Tests ajoutés ou mis à jour si nécessaire
- [x] Docs mises à jour si nécessaire
